### PR TITLE
make input_file available for the latex template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt update && \
        texlive-xetex \
        texlive \
        texlive-latex-extra \
+       texlive-generic-extra \
        texlive-bibtex-extra \
        texlive-fonts-recommended \
        tree \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -208,13 +208,17 @@ else
                 COMMAND="/usr/bin/pandoc"
                 generate_mappings "${INPUT_MAPPING_FILE}" "${INPUT_VARIABLES_FILE}" mappings.txt
                 mappings=$(cat mappings.txt)
+                
+                # get filename relative to input dir and without .md extension
+                REL_INPUT=$(realpath --relative-to=${INPUT_PAPER_DIR} ${INPUT_PAPER_MARKDOWN})
+                REL_INPUT=$(basename ${REL_INPUT%.md})
 
                 # Bibliography?
                 if [ ! -z "${INPUT_BIBTEX}" ]; then
                     COMMAND="${COMMAND} --bibliography ${INPUT_BIBTEX}"
                 fi
 
-                COMMAND="${COMMAND} ${mappings} -V graphics=\"true\" -V logo_path=\"${INPUT_PNG_LOGO}\" -V geometry:margin=1in --verbose -o ${outfile} --pdf-engine=xelatex --filter /usr/bin/pandoc-citeproc ${INPUT_PAPER_MARKDOWN} --from markdown+autolink_bare_uris --template ${INPUT_LATEX_TEMPLATE}"
+                COMMAND="${COMMAND} ${mappings} -V graphics=\"true\" -V logo_path=\"${INPUT_PNG_LOGO}\" -V input_file=\"${REL_INPUT}\" -V geometry:margin=1in --verbose -o ${outfile} --pdf-engine=xelatex --filter /usr/bin/pandoc-citeproc ${INPUT_PAPER_MARKDOWN} --from markdown+autolink_bare_uris --template ${INPUT_LATEX_TEMPLATE}"
                 printf "$COMMAND\n"
                 printf "${COMMAND}" > pandoc_run.sh
                 chmod +x pandoc_run.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Change working directory
 if [ ! -z "${INPUT_WORKDIR}" ]; then
     printf "Changing working directory to ${INPUT_WORKDIR}\n"
@@ -162,7 +164,7 @@ if [ "${INPUT_PDF_TYPE}" == "minimal" ]; then
             else
                 outdir=$(dirname "${INPUT_PAPER_MARKDOWN}")
                 outfile="${outdir}/${outfile}"
-            fi 
+            fi
             # Only run if outfile does not exist
             if [ ! -f "${outfile}" ]; then
                 generate_minimal "${INPUT_PAPER_MARKDOWN}" "${outfile}" "${INPUT_BIBTEX}"
@@ -200,7 +202,7 @@ else
             else
                 outdir=$(dirname "${INPUT_PAPER_MARKDOWN}")
                 outfile="${outdir}/${outfile}"
-            fi 
+            fi
 
             # Only run if outfile does not exist
             if [ ! -f "${outfile}" ]; then
@@ -208,7 +210,7 @@ else
                 COMMAND="/usr/bin/pandoc"
                 generate_mappings "${INPUT_MAPPING_FILE}" "${INPUT_VARIABLES_FILE}" mappings.txt
                 mappings=$(cat mappings.txt)
-                
+
                 # get filename relative to input dir and without .md extension
                 REL_INPUT=$(realpath --relative-to=${INPUT_PAPER_DIR} ${INPUT_PAPER_MARKDOWN})
                 REL_INPUT=$(basename ${REL_INPUT%.md})

--- a/templates/latex.template.sorse
+++ b/templates/latex.template.sorse
@@ -15,6 +15,7 @@
 \usepackage{amssymb,amsmath}
 \usepackage{ifxetex,ifluatex}
 \usepackage{seqsplit}
+\usepackage[en-US]{datetime2}
 \usepackage{fixltx2e} % provides \textsubscript
 \usepackage[
   backend=biber,
@@ -323,12 +324,12 @@ $endif$
   \begin{itemize}
     \setlength\itemsep{0em}
     \item \href{https://sorse.github.io}{\color{linky}{SORSE}} \ExternalLink
-    $if(website)$\item \href{$website$}{\color{linky}{Event Website}} \ExternalLink$endif$
+    \item \href{https://sorse.github.io/programme/$input_file$/}{\color{linky}{Event Website}} \ExternalLink
   \end{itemize}
   \vspace{2mm}
 
   {\bfseries Category:} $category$\\
-  {\bfseries Published:} $published$
+  {\bfseries Published:} \DTMdate{$date$}
 
   \vspace{2mm}
   {\bfseries License}\\

--- a/templates/sorse-variables.txt
+++ b/templates/sorse-variables.txt
@@ -1,4 +1,4 @@
 journal_name SORSE
-published July 6, 2020
+date 2020-07-06
 website https://github.com/rseng/pdf-generator
 year 2020


### PR DESCRIPTION
this commit adds the path of the markdown file relative to the input directory and without extension as $input_file& metadata.

With this setting, a file like `_events/software_demo/event-001.md` would be available as `software_demo/event-001` in the latex template through `$input_file$`. Then I could use in the SORSE template at SORSE/sorse.github.io#218 something like `\item \href{https://sorse.github.io/programme/$input_file$/}{\color{linky}{Event Website}} \ExternalLink`